### PR TITLE
Added cmake configuration for easier build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /build
 /doc
 .vscode
+cmake-build-debug

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.10)
+project(composition-cpp)
+
+# Executing CMakeLists.txt in subdirs
+add_subdirectory(include)
+add_subdirectory(src)
+
+# Adding executable binary with sources and headers from subdirs
+add_executable(composition_cpp ${SOURCES} ${HEADERS})
+# Linking Math.h binary library (I don't know if it's necessary, but let it be :D)
+target_link_libraries(composition_cpp m)
+# Including headers dirs for #include <CMatrix.h> (not #include <../include/CMatrix.h>)
+target_include_directories(composition_cpp PRIVATE include)

--- a/README.md
+++ b/README.md
@@ -5,3 +5,10 @@
 ```sh
 sh build.sh test
 ```
+
+```shell
+cmake -S ./ -B ./build
+cd build
+make -j 4
+./composition_cpp
+```

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -1,0 +1,6 @@
+
+set(HEADERS
+        ${CMAKE_CURRENT_SOURCE_DIR}/CMatrix.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/CWhole.h
+
+        PARENT_SCOPE)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,7 @@
+
+set(SOURCES
+        ${CMAKE_CURRENT_SOURCE_DIR}/CMatrix.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/CWhole.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/test.cpp
+
+        PARENT_SCOPE)

--- a/src/CMatrix.cpp
+++ b/src/CMatrix.cpp
@@ -1,4 +1,4 @@
-#include "../include/CMatrix.h"
+#include "CMatrix.h"
 
 CMatrix::CMatrix(): size(4) {
   create();

--- a/src/CWhole.cpp
+++ b/src/CWhole.cpp
@@ -1,4 +1,4 @@
-#include "../include/CWhole.h"
+#include "CWhole.h"
 
 CWhole::CWhole() {
   length = 0;

--- a/src/test.cpp
+++ b/src/test.cpp
@@ -1,7 +1,7 @@
 #include <iostream>
 
-#include "include/CMatrix.h"
-#include "include/CWhole.h"
+#include "CMatrix.h"
+#include "CWhole.h"
 
 using namespace std;
 


### PR DESCRIPTION
Building with g++ with your own hands is deprecated. A less obsolete method is makefile\autoconf\configure. The most used method today is cmake or meson.